### PR TITLE
Exercises 1–3: Provider models and query script

### DIFF
--- a/provider_pipeline/models/provider_address_agg.sql
+++ b/provider_pipeline/models/provider_address_agg.sql
@@ -1,0 +1,23 @@
+with provider_with_addresses as (
+
+    select 
+        p.id as provider_id,
+        p.first_name || ' ' || p.last_name as provider_name,
+        coalesce(
+            array_agg(
+                struct_pack(
+                    address_id := a.id,
+                    street := a.street,
+                    rank := a.rank
+                )
+            ) filter (where a.id is not null), 
+            []
+        ) as addresses
+    from {{ ref('providers') }} p
+    left join {{ ref('addresses') }} a 
+        on p.id = a.id
+    group by p.id, p.first_name, p.last_name
+
+)
+
+select * from provider_with_addresses

--- a/provider_pipeline/models/provider_types.sql
+++ b/provider_pipeline/models/provider_types.sql
@@ -1,0 +1,32 @@
+with split_degrees as (
+
+    select
+        p.id as provider_id,
+        p.first_name || ' ' || p.last_name as provider_name,
+        unnest(string_split(p.degrees, ',')) as degree
+    from {{ ref('providers') }} p
+
+),
+
+ranked_degrees as (
+
+    select
+        s.provider_id,
+        s.provider_name,
+        d.ptui,
+        d.rank,
+        row_number() over (
+            partition by s.provider_id
+            order by d.rank asc
+        ) as rn
+    from split_degrees s
+    join {{ ref('degree_types') }} d
+        on trim(s.degree) = d.degree
+)
+
+select
+    provider_id,
+    provider_name,
+    ptui
+from ranked_degrees
+where rn = 1

--- a/provider_pipeline/query_duckdb.py
+++ b/provider_pipeline/query_duckdb.py
@@ -1,0 +1,10 @@
+import duckdb
+import pandas as pd
+
+def query_duckdb():
+    con = duckdb.connect("dev.duckdb")
+    df = con.execute("SELECT * FROM main.provider_address_agg").fetchdf()
+    return df
+
+if __name__ == "__main__":
+    print(query_duckdb())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,7 @@ python = "^3.11"
 dbt-core = "^1.8.8"
 dbt-duckdb = "^1.9.0"
 pytest = "^8.3.4"
+pandas = "^2.3.2"
 
 [tool.pytest.ini_options]
 


### PR DESCRIPTION
- Exercise 1: Added provider_address_agg model combining providers and addresses
- Exercise 2: Added provider_types model joining providers with degree types
- Exercise 3: Added pandas dependency and query_duckdb.py script for provider_address_agg
